### PR TITLE
Deploy docs only if they are changed

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -27,8 +27,8 @@ jobs:
     - name: Check for modifications in docs
       id: changed-docs
       uses: tj-actions/changed-files@v37
-        with:
-          files: docs/*
+      with:
+        files: docs/*
 
     - name: Setup Pages
       if: steps.changed-docs.outputs.any_changed == 'true'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,18 +24,28 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Check for modifications in docs
+      id: changed-docs
+      uses: tj-actions/changed-files@v37
+        with:
+          files: docs/*
+
     - name: Setup Pages
+      if: steps.changed-docs.outputs.any_changed == 'true'
       uses: actions/configure-pages@v3
     
     - name: Build HTML
+      if: steps.changed-docs.outputs.any_changed == 'true'
       uses: ammaraskar/sphinx-action@master
       
     - name: Upload artifacts
+      if: steps.changed-docs.outputs.any_changed == 'true'
       uses: actions/upload-pages-artifact@v1
       with:
         name: github-pages
         path: docs/build/html/
         
     - name: Deploy
+      if: steps.changed-docs.outputs.any_changed == 'true'
       id: deployment
       uses: actions/deploy-pages@v2


### PR DESCRIPTION
Docs deployment workflow modified the way that it would not build and deploy docs after commits that does not change anything in `docs` directory